### PR TITLE
make TextGrid-conversion independent and added jtgt v5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ Gradle MaryTTS Kaldi MFA Plugin
 ------------
 
 ### Changes
-
+- updated jtgt to v5.3
+- removed dependency in `convertTextGridToXlab.groovy`
+    - this task can now also be used for other TextGrids
 - updated jtgt to stable release
 - updated the documentation
 - added `labelMapping`

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ convertTextGridToXLab {
 }
 ```
 
+#### Using *convertTextGridToXLab* alone
+If you want to use `convertTextGridToXLab` alone you may want to override the default TextGrid-directory which is `build/TextGrid/forcedAlignment`:
+```
+convertTextGridToXLab.tgDir = file("$buildDir/TextGrid")
+```
+
 [Kaldi]: http://kaldi-asr.org/
 [MaryTTS]: http://mary.dfki.de/
 [Montreal Forced Aligner]: https://montrealcorpustools.github.io/Montreal-Forced-Aligner/

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     compile group: 'de.undercouch', name: 'gradle-download-task', version: '3.3.0'
-    compile group: 'org.m2ci.msp', name: 'jtgt', version: '0.5.2'
+    compile group: 'org.m2ci.msp', name: 'jtgt', version: '0.5.3'
     runtime group: 'de.dfki.mary', name: 'marytts-voicebuilding', version: '0.1', {
         exclude module: 'groovy-all'
     }

--- a/src/main/groovy/de/dfki/mary/voicebuilding/MaryttsKaldiMfaPlugin.groovy
+++ b/src/main/groovy/de/dfki/mary/voicebuilding/MaryttsKaldiMfaPlugin.groovy
@@ -52,10 +52,7 @@ class MaryttsKaldiMfaPlugin implements Plugin<Project> {
             srcDir = project.prepareForcedAlignment.forcedAlignmentDir
         }
 
-        project.task('convertTextGridToXLab', type: ConvertTextGridToXLab) {
-            dependsOn project.runForcedAlignment
-            tgDir = project.runForcedAlignment.destDir
-        }
+        project.task('convertTextGridToXLab', type: ConvertTextGridToXLab)
     }
 
     Map getMFADependencyFor(Project project) {

--- a/src/main/groovy/de/dfki/mary/voicebuilding/tasks/ConvertTextGridToXLab.groovy
+++ b/src/main/groovy/de/dfki/mary/voicebuilding/tasks/ConvertTextGridToXLab.groovy
@@ -8,10 +8,13 @@ import org.m2ci.msp.jtgt.io.*
 class ConvertTextGridToXLab extends DefaultTask {
 
     @InputDirectory
-    File tgDir
+    File tgDir = project.file("$project.buildDir/TextGrid/forcedAlignment")
 
     @Input
     Map<String, String> labelMapping = [sil: '_', sp: '_']
+
+    @Input
+    String tiername = "phones"
 
     @OutputDirectory
     File destDir = project.file("$project.buildDir/lab")
@@ -20,16 +23,16 @@ class ConvertTextGridToXLab extends DefaultTask {
     void convert() {
         def tgSer = new TextGridSerializer()
         def xLabSer = new XWaveLabelSerializer()
-        project.fileTree("$tgDir/forcedAlignment").include('*.TextGrid').collect { tgFile ->
+        project.fileTree(tgDir).include('*.TextGrid').collect { tgFile ->
             def tg = tgSer.fromString(tgFile.text)
-            tg.tiers.find { it.name == 'phones' }.annotations.each {
+            tg.tiers.find { it.name == tiername }.annotations.each {
                 it.text = labelMapping[it.text] ?: it.text
                 if (it.text == '') {
                     it.text = "_"
                 }
             }
 
-            def xlabStr = xLabSer.toString(tg, 'phones')
+            def xlabStr = xLabSer.toString(tg, tiername)
 
             def xlabFile = project.file("$destDir/${tgFile.name - '.TextGrid' + '.lab'}")
             xlabFile.text = xlabStr

--- a/src/test/resources/de/dfki/mary/voicebuilding/build.gradle
+++ b/src/test/resources/de/dfki/mary/voicebuilding/build.gradle
@@ -55,3 +55,5 @@ task convertTextPrompts {
 convertTextToMaryXml.dependsOn convertTextPrompts
 
 prepareForcedAlignment.wavDir = file("$buildDir/unpacked/cmu_time_awb/wav")
+
+convertTextGridToXLab.dependsOn runForcedAlignment


### PR DESCRIPTION
removed `convertTextGridToXlab`'s  dependency on `runForcedAlignment`